### PR TITLE
fix: text resizing issue; added vertical resizng of meme text editor  

### DIFF
--- a/src/components/CustomTemplateUpload.tsx
+++ b/src/components/CustomTemplateUpload.tsx
@@ -87,7 +87,7 @@ export default function CustomTemplateUpload({
                                 x: Math.max(20, img.width * 0.05),
                                 y: Math.max(50, img.height * 0.1),
                                 width: Math.min(img.width * 0.9, img.width - 40),
-                                height: Math.min(img.height * 0.2, 150),
+                                height: Math.max(img.height * 0.2, 150),
                                 fontSize: Math.max(30, Math.min(img.width, img.height) * 0.08),
                                 minFont: 20,
                                 align: 'center' as const
@@ -96,7 +96,7 @@ export default function CustomTemplateUpload({
                                 x: Math.max(20, img.width * 0.05),
                                 y: Math.max(img.height * 0.7, img.height - 200),
                                 width: Math.min(img.width * 0.9, img.width - 40),
-                                height: Math.min(img.height * 0.2, 150),
+                                height: Math.max(img.height * 0.2, 150),
                                 fontSize: Math.max(30, Math.min(img.width, img.height) * 0.08),
                                 minFont: 20,
                                 align: 'center' as const
@@ -119,7 +119,7 @@ export default function CustomTemplateUpload({
                                     x: Math.max(20, img.width * 0.05),
                                     y: Math.max(50, img.height * 0.1),
                                     width: Math.min(img.width * 0.9, img.width - 40),
-                                    height: Math.min(img.height * 0.2, 150),
+                                    height: Math.max(img.height * 0.2, 150),
                                     fontSize: Math.max(30, Math.min(img.width, img.height) * 0.08),
                                     minFont: 20,
                                     align: 'center' as const
@@ -128,7 +128,7 @@ export default function CustomTemplateUpload({
                                     x: Math.max(20, img.width * 0.05),
                                     y: Math.max(img.height * 0.7, img.height - 200),
                                     width: Math.min(img.width * 0.9, img.width - 40),
-                                    height: Math.min(img.height * 0.2, 150),
+                                    height: Math.max(img.height * 0.2, 150),
                                     fontSize: Math.max(30, Math.min(img.width, img.height) * 0.08),
                                     minFont: 20,
                                     align: 'center' as const


### PR DESCRIPTION
This pull request adds support for resizing the height of text boxes in the meme editor, in addition to the existing width resizing. It introduces new UI handles for adjusting the top and bottom edges of text boxes, updates the resizing logic to handle vertical resizing, and ensures the visual indicators and cursor feedback are consistent with the new functionality.

**Text Box Height Resizing Support:**

* Added new state variables (`isResizingTextHeight`, `isResizingFromTop`) and logic to handle height resizing for text boxes, including determining which handle (top or bottom) is being dragged. [[1]](diffhunk://#diff-338e6805f4d48f6f9b8a819ba6b19de71ce314f8b88da00542fcf3308a0aeb91R50-R52) [[2]](diffhunk://#diff-338e6805f4d48f6f9b8a819ba6b19de71ce314f8b88da00542fcf3308a0aeb91R573-R582) [[3]](diffhunk://#diff-338e6805f4d48f6f9b8a819ba6b19de71ce314f8b88da00542fcf3308a0aeb91R740-R759) [[4]](diffhunk://#diff-338e6805f4d48f6f9b8a819ba6b19de71ce314f8b88da00542fcf3308a0aeb91R818-R820) [[5]](diffhunk://#diff-338e6805f4d48f6f9b8a819ba6b19de71ce314f8b88da00542fcf3308a0aeb91R880-R886) [[6]](diffhunk://#diff-338e6805f4d48f6f9b8a819ba6b19de71ce314f8b88da00542fcf3308a0aeb91L994-R1065)
* Updated the function for detecting which resize handle is under the cursor to include top and bottom handles for height adjustment.
* Modified the mouse event handlers to support vertical resizing, including updating the cursor to `ns-resize` when hovering over height handles. [[1]](diffhunk://#diff-338e6805f4d48f6f9b8a819ba6b19de71ce314f8b88da00542fcf3308a0aeb91L737-R780) [[2]](diffhunk://#diff-338e6805f4d48f6f9b8a819ba6b19de71ce314f8b88da00542fcf3308a0aeb91R818-R820)
* Updated the rendering logic to draw top and bottom resize handles, vertical connector lines, and height indicators on the canvas for the selected text box.

**Default Text Box Height Logic:**

* Changed the default height calculation for new text boxes in `CustomTemplateUpload.tsx` to use `Math.max` instead of `Math.min`, ensuring a minimum height of 150px or 20% of the image height, whichever is greater. [[1]](diffhunk://#diff-b54a2aadf85fd620000cde702d42de5df0c4d9911cb5ad43a748f1000eb80853L90-R90) [[2]](diffhunk://#diff-b54a2aadf85fd620000cde702d42de5df0c4d9911cb5ad43a748f1000eb80853L99-R99) [[3]](diffhunk://#diff-b54a2aadf85fd620000cde702d42de5df0c4d9911cb5ad43a748f1000eb80853L122-R122) [[4]](diffhunk://#diff-b54a2aadf85fd620000cde702d42de5df0c4d9911cb5ad43a748f1000eb80853L131-R131)

https://github.com/user-attachments/assets/ecee7c06-c72d-4763-b5c0-3764591cd43f


